### PR TITLE
removed unuser variables in encoder_cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ TestResults
 ClientBin
 stylecop.*
 ~$*
+*~
 *.dbmdl
 Generated_Code #added for RIA/Silverlight projects
 

--- a/encoder/codec.h
+++ b/encoder/codec.h
@@ -183,7 +183,7 @@ typedef struct{
 
 extern void encode_image(image_buffer *im,encode_state *enc, int ratio);
 
-extern int menu(char *file_name,image_buffer *im,encode_state *os,int rate);
+extern int read_image_bmp(char *file_name, encode_state *os, image_buffer *im, int rate);
 extern int write_compressed_file(image_buffer *im,encode_state *enc,char *file_name);
 
 extern void downsample_YUV420(image_buffer *im,encode_state *enc,int rate);

--- a/encoder/nhw_encoder.c
+++ b/encoder/nhw_encoder.c
@@ -2836,7 +2836,6 @@ L_W5:			res256[count]=14000;
 
 }
 
-///int menu(char *file_name,image_buffer *im,encode_state *os,int rate)
 int read_image_bmp(char *file_name, encode_state *os, image_buffer *im, int rate)
 {
 	FILE *im256;

--- a/encoder/nhw_encoder.c
+++ b/encoder/nhw_encoder.c
@@ -64,7 +64,7 @@ void encode_image(image_buffer *im,encode_state *enc, int ratio)
 	int stage,wavelet_order,end_transform,i,j,e=0,a=0,Y,count,scan,res,res_setting,res_uv,y_wavelet,y_wavelet2;
 	unsigned char *highres,*ch_comp,*scan_run,*nhw_res1I_word,*nhw_res3I_word,*nhw_res5I_word;
 	unsigned char wvlt_thrx1,wvlt_thrx2,wvlt_thrx3,wvlt_thrx4,wvlt_thrx5,wvlt_thrx6,wvlt_thrx7;
-	short *res256,*resIII,*nhw_process,*nhw_process2;
+	short *res256,*resIII,*nhw_process;
 
 	im->im_process=(short*)malloc(4*IM_SIZE*sizeof(short));
 
@@ -2836,11 +2836,10 @@ L_W5:			res256[count]=14000;
 
 }
 
-int menu(char *file_name,image_buffer *im,encode_state *os,int rate)
+///int menu(char *file_name,image_buffer *im,encode_state *os,int rate)
+int read_image_bmp(char *file_name, encode_state *os, image_buffer *im, int rate)
 {
-	int i;
 	FILE *im256;
-	unsigned char *im4;
 
 	// INITS & MEMORY ALLOCATION FOR ENCODING
 	//im->setup=(codec_setup*)malloc(sizeof(codec_setup));

--- a/encoder/nhw_encoder_cli.c
+++ b/encoder/nhw_encoder_cli.c
@@ -52,7 +52,7 @@
 #define PROGRAM "nhw-enc"
 #define VERSION "0.2.8"
 
-#define NHW_QUALITY_MIN LOW19
+#define NHW_QUALITY_MIN LOW20
 #define NHW_QUALITY_MAX HIGH3
 
 extern char bmp_header[54];
@@ -60,7 +60,7 @@ extern char bmp_header[54];
 void show_usage()
 {
 	fprintf(stdout,
-	"Usage: %s [-hq] <image.bmp> <image.nhw>\n"
+	"Usage: %s [-hV][-q<quality>] <image.bmp> <image.nhw>\n"
 	"Convert image: bmp to nwh\n"
 	" (with a bitmap color 512x512 image)\n"
 	"Options:\n"
@@ -90,7 +90,6 @@ int main(int argc, char **argv)
 	encode_state enc;
 	char *ifname, *ofname;
 	int select, quality, ofoverwrite;
-	char *arg;
 
 	quality = NORM;
 
@@ -113,7 +112,7 @@ int main(int argc, char **argv)
 			;
 			break;
 		case 'q':
-			if ((argv[1][i+1]!='\0') && (argv[1][i+1]>'0') && (argv[1][i+1]<='9'))
+			if ((argv[1][i+1]!='\0') && (argv[1][i+1]>='0') && (argv[1][i+1]<='9'))
 			{
 				quality = atoi(&argv[1][i+1]);
 				if ((quality<NHW_QUALITY_MIN) || (quality>NHW_QUALITY_MAX))
@@ -150,8 +149,9 @@ int main(int argc, char **argv)
 
 	if (argc<3)
 	{
-		printf("Not enough arguments. Try `-h' for help.\n");
-		exit(1);
+		printf("Not enough arguments. Check help.\n");
+		show_usage();
+		return 0;
 	}
 	ifname = argv[1];
 	ofname = argv[2];
@@ -166,8 +166,8 @@ int main(int argc, char **argv)
 		if (fy)
 		{
 			fclose(fy);
-		fprintf(stderr, "File '%s' already exists. Try `-f' to overwrite.\n", ofname);
-		return 1;
+			fprintf(stderr, "File '%s' already exists. Try `-f' to overwrite.\n", ofname);
+			return 1;
 		}
 	}
 
@@ -175,12 +175,13 @@ int main(int argc, char **argv)
 	im.setup->quality_setting=quality;
 	select = 8;
 
-	menu(ifname,&im,&enc,select);
-
+	//menu(ifname,&im,&enc,select);
+	read_image_bmp(ifname, &enc, &im, select);
+	//int read_image_bmp(char *file_name, encode_state *os, image_buffer *im, int rate)
 	/* Encode Image */
-	encode_image(&im,&enc,select);
+	encode_image(&im, &enc, select);
 
-	write_compressed_file(&im,&enc,ofname);
+	write_compressed_file(&im, &enc, ofname);
 
 	return 0;
 }

--- a/encoder/nhw_encoder_cli.c
+++ b/encoder/nhw_encoder_cli.c
@@ -175,9 +175,7 @@ int main(int argc, char **argv)
 	im.setup->quality_setting=quality;
 	select = 8;
 
-	//menu(ifname,&im,&enc,select);
 	read_image_bmp(ifname, &enc, &im, select);
-	//int read_image_bmp(char *file_name, encode_state *os, image_buffer *im, int rate)
 	/* Encode Image */
 	encode_image(&im, &enc, select);
 


### PR DESCRIPTION
more readable functions naming
allow quality=0, for debug mainly (not specified in help) print help without arguments (to be consistent with decoder) added *~ to .gitignore
